### PR TITLE
Reselecting the kernel now loads the new modules

### DIFF
--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -55,7 +55,6 @@ sed 's/^ \{2\}//' > "<%= wrapper %>" << EOL
   exec &>>"<%= wrapper_log %>"
 
   # Load the required environment
-  module purge
   module load \${MODULES}
   module list
 


### PR DESCRIPTION
When using the `jupyterldmod` extension to load an extra module from the cluster, the default `Python 3.11.3` kernel would not see the new modules (they were purged and only Jupyter-bundle was reloaded). Now the kernel does see the extra modules, once it has be re-selected (restarting it only doesn't seem to work).